### PR TITLE
Fix modules not found when running dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,15 @@
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
     "lodash": "^4.17.21",
+    "module-alias": "^2.2.2",
     "node-fetch": "^2.6.1",
     "tsconfig-paths": "^3.9.0"
+  },
+  "_moduleAliases": {
+    "@core": "dist/src/core/",
+    "@config": "dist/src/config",
+    "@typings": "dist/src/typings",
+    "@helpers": "dist/src/helpers",
+    "@tests/": "dist/src/test"
   }
 }

--- a/src/core/query/query.ts
+++ b/src/core/query/query.ts
@@ -8,6 +8,6 @@ export async function Query<M extends Modes>(mode: M, id: string) {
     const url = buildQueryURL({ mode, id })
     const data = await fetch(url)
         .then(response => response.text())
-        .then(data => JSON.parse(data))
+        .then(data => JSON.parse(data.trim()))
     return Builder<M>(mode)(data)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'module-alias/register';
+
 export * from '@core/query'
 export * from '@core/scraper'
 export * from '@core/search'


### PR DESCRIPTION
I believe this fixes it. Definitely try it out. 

But I also get a runtime error when I run a query. It seems to fail at parsing the json response from the constructed url even though its seems correct. I tried querying product recipe for item '9213'